### PR TITLE
Restructure push mixin nesting

### DIFF
--- a/app/assets/stylesheets/mixins/_grid-push.scss
+++ b/app/assets/stylesheets/mixins/_grid-push.scss
@@ -3,13 +3,14 @@
 @mixin grid-push(
     $push: false
   ) {
+  @include grid-is-zero-error(grid-push, $push);
+
   @if $push {
     $_grid-gutter-affordance: $grid-gutter * $push;
     $_margin-value: calc(#{unquote(grid-calc($push))} + #{$_grid-gutter-affordance});
+    margin-#{$default-float}: $_margin-value;
   } @else {
     $_margin-value: $grid-gutter;
+    margin-#{$default-float}: $_margin-value;
   }
-
-  @include grid-is-zero-error(grid-push, $push);
-  margin-#{$default-float}: $_margin-value;
 }


### PR DESCRIPTION
Some libraries handle variable nesting unreliably. To cover these cases, the push mixin has been restructured to return this value directly instead of modifying a variable and then returning it.
